### PR TITLE
Add Opcode verifier

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,3 +8,4 @@ edition = "2021"
 
 [dependencies]
 static_assertions = "1.1.0"
+thiserror = "1.0"

--- a/src/bytecode.rs
+++ b/src/bytecode.rs
@@ -1,6 +1,7 @@
 pub mod bytecode {
+
     #[warn(dead_code, unused_variables)]
-    #[derive(Debug)]
+    #[derive(Debug, PartialEq, Eq, PartialOrd, Ord)]
     pub enum Opcode {
         // stack
         Load,  // 1 operand, loads FROM locals TO stack
@@ -12,7 +13,7 @@ pub mod bytecode {
         Jump,
         JumpCond,
         Call, // 1 operand, enters new stack frame
-        Ret,  // 1 operand, leaves the current stack frame, write return addr to local.
+        Ret,  // 0 operand, leaves the current stack frame, write return addr to local.
         // math
         Incr,
         Decr,

--- a/src/interpreter.rs
+++ b/src/interpreter.rs
@@ -36,12 +36,17 @@ pub mod vm {
     }
 
     impl StackFrame {
-        pub(crate) fn new(args: Vec<i32>, locals: Vec<i32>, instr: BTreeMap<i32, Bytecode>) -> Result<StackFrame, StackFrameError> {
+        pub(crate) fn new(
+            args: Vec<i32>,
+            locals: Vec<i32>,
+            instr: BTreeMap<i32, Bytecode>,
+        ) -> Result<StackFrame, StackFrameError> {
             (StackFrame {
                 args,
                 locals,
                 instructions: instr,
-            }).verify()
+            })
+            .verify()
         }
 
         fn verify(self) -> Result<StackFrame, StackFrameError> {
@@ -58,9 +63,8 @@ pub mod vm {
             for instr in &self.instructions {
                 let opcode = &instr.1.opcode;
                 let operands = &instr.1.operands;
-                if operands_num.contains_key(opcode)
-                    && operands_num.get(opcode).unwrap() != &operands.len() {
-                    return Err(StackFrameError::IncorrectOperandsNumber(operands.len()))
+                if operands_num.contains_key(opcode) && operands_num.get(opcode).unwrap() != &operands.len() {
+                    return Err(StackFrameError::IncorrectOperandsNumber(operands.len()));
                 }
 
                 match opcode {
@@ -70,30 +74,28 @@ pub mod vm {
                             return Err(StackFrameError::UnreachableLocal(operand));
                         }
                         stack_size += 1;
-                    },
+                    }
                     Opcode::Store => {
                         let operand = operands[0] as usize;
                         if operand >= self.locals.len() {
                             return Err(StackFrameError::UnreachableLocal(operand));
                         }
                         stack_size -= 1;
-                    },
-                    Opcode::Push => {
-                        stack_size += 1
-                    },
+                    }
+                    Opcode::Push => stack_size += 1,
                     Opcode::Pop | Opcode::Ret => {
                         if stack_size < 1 {
                             return Err(StackFrameError::EmptyStack);
                         }
                         stack_size -= 1;
-                    },
+                    }
                     Opcode::Pop2 => {
                         if stack_size < 2 {
                             return Err(StackFrameError::EmptyStack);
                         }
                         stack_size -= 2;
-                    },
-                    _ => return Err(StackFrameError::UnsupportedInstruction)
+                    }
+                    _ => return Err(StackFrameError::UnsupportedInstruction),
                 }
                 println!("Verify {:?}. Stack size: {}", opcode, stack_size)
             }

--- a/src/interpreter.rs
+++ b/src/interpreter.rs
@@ -23,13 +23,81 @@ pub mod vm {
         }
     }
 
+    #[derive(Debug, thiserror::Error)]
+    pub enum StackFrameError {
+        #[error("instruction is not supported")] // TODO: pass opcode name
+        UnsupportedInstruction,
+        #[error("instruction has wrong number of operands: {0}")]
+        IncorrectOperandsNumber(usize),
+        #[error("empty stack")] // TODO: pass opcode name
+        EmptyStack,
+        #[error("unreachable local: no {0}th local")]
+        UnreachableLocal(usize),
+    }
+
     impl StackFrame {
-        pub(crate) fn new(args: Vec<i32>, locals: Vec<i32>, instr: BTreeMap<i32, Bytecode>) -> StackFrame {
-            StackFrame {
+        pub(crate) fn new(args: Vec<i32>, locals: Vec<i32>, instr: BTreeMap<i32, Bytecode>) -> Result<StackFrame, StackFrameError> {
+            (StackFrame {
                 args,
                 locals,
                 instructions: instr,
+            }).verify()
+        }
+
+        fn verify(self) -> Result<StackFrame, StackFrameError> {
+            let mut operands_num: BTreeMap<Opcode, usize> = BTreeMap::new();
+            operands_num.insert(Opcode::Load, 1);
+            operands_num.insert(Opcode::Store, 1);
+            operands_num.insert(Opcode::Push, 1);
+            operands_num.insert(Opcode::Pop, 0);
+            operands_num.insert(Opcode::Pop2, 0);
+            operands_num.insert(Opcode::Ret, 0);
+
+            let mut stack_size = 0;
+
+            for instr in &self.instructions {
+                let opcode = &instr.1.opcode;
+                let operands = &instr.1.operands;
+                if operands_num.contains_key(opcode)
+                    && operands_num.get(opcode).unwrap() != &operands.len() {
+                    return Err(StackFrameError::IncorrectOperandsNumber(operands.len()))
+                }
+
+                match opcode {
+                    Opcode::Load => {
+                        let operand = operands[0] as usize;
+                        if operand >= self.locals.len() {
+                            return Err(StackFrameError::UnreachableLocal(operand));
+                        }
+                        stack_size += 1;
+                    },
+                    Opcode::Store => {
+                        let operand = operands[0] as usize;
+                        if operand >= self.locals.len() {
+                            return Err(StackFrameError::UnreachableLocal(operand));
+                        }
+                        stack_size -= 1;
+                    },
+                    Opcode::Push => {
+                        stack_size += 1
+                    },
+                    Opcode::Pop | Opcode::Ret => {
+                        if stack_size < 1 {
+                            return Err(StackFrameError::EmptyStack);
+                        }
+                        stack_size -= 1;
+                    },
+                    Opcode::Pop2 => {
+                        if stack_size < 2 {
+                            return Err(StackFrameError::EmptyStack);
+                        }
+                        stack_size -= 2;
+                    },
+                    _ => return Err(StackFrameError::UnsupportedInstruction)
+                }
+                println!("Verify {:?}. Stack size: {}", opcode, stack_size)
             }
+            Ok(self)
         }
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,8 +13,11 @@ fn main() {
     instr.insert(2, Bytecode::new(Opcode::Load, vec![0]));
     instr.insert(3, Bytecode::new(Opcode::Ret, vec![]));
 
-    let frame: vm::StackFrame = vm::StackFrame::new(vec![], vec![0; 4], instr);
-    let mut interpreter: Interpreter = Interpreter::new(frame);
-
-    interpreter.run();
+    match vm::StackFrame::new(vec![], vec![0; 4], instr) {
+        Err(err) => println!("Stack frame is not correct: {}.", err),
+        Ok(frame) => {
+            let mut interpreter: Interpreter = Interpreter::new(frame);
+            interpreter.run();
+        }
+    }
 }


### PR DESCRIPTION
Adds a simple opcode verifier that checks for:
* the number of operands for each instruction
* the stack is not empty when a value is required
* the presence of the required local

No tests yet -- I'll add them after merge #2.